### PR TITLE
Adjust visual grid to give defined gutter edges

### DIFF
--- a/src/Mixins/gridVisual.js
+++ b/src/Mixins/gridVisual.js
@@ -13,7 +13,7 @@ let gridVisual: Function = (theme: typeof NeatTheme): Styles => {
   return {
     'background-image': `
       repeating-linear-gradient(
-        to right, transparent, transparent,
+        to right, transparent, transparent ${gutter},
         ${color} ${gutter},
         ${color} calc(${columnWidth(theme, 1)} + ${gutter})
       )

--- a/src/Mixins/gridVisual.test.js
+++ b/src/Mixins/gridVisual.test.js
@@ -9,7 +9,7 @@ describe('gridVisual()', () => {
     expect(result.hasOwnProperty('background-image')).toBe(true)
     expect(result['background-image'].replace(/\s+/g, ' ').trim()).toEqual(`
       repeating-linear-gradient(
-        to right, transparent, transparent, ${color} 20px,
+        to right, transparent, transparent 20px, ${color} 20px,
         ${color} calc(${columnWidth(Neat(), 1)} + 20px)
       )`.replace(/\s+/g, ' ').trim()
     )
@@ -29,7 +29,7 @@ describe('gridVisual()', () => {
     expect(result.hasOwnProperty('background-image')).toBe(true)
     expect(result['background-image'].replace(/\s+/g, ' ').trim()).toEqual(`
       repeating-linear-gradient(
-        to right, transparent, transparent, 20px,
+        to right, transparent, transparent 20px, 20px,
         calc(${columnWidth(Neat(), 1)} + 20px)
       )`.replace(/\s+/g, ' ').trim()
     )


### PR DESCRIPTION
# What
- adds a length stop to the linear gradient on the `visualGradient` helper.

#Why

### Before
<img width="1271" alt="Screen Shot 2021-01-25 at 9 39 52 pm" src="https://user-images.githubusercontent.com/892840/105695199-ed1ea700-5f55-11eb-819d-5d4d446e82e4.png">
Without the length stop on the gutter's right edge, the gutters have a gradient from transparent to the theme colour.

### After

<img width="1275" alt="Screen Shot 2021-01-25 at 9 40 05 pm" src="https://user-images.githubusercontent.com/892840/105695212-f14ac480-5f55-11eb-9cce-136ae802d0e4.png">
With the length stop, the gutters edges are well defined.
